### PR TITLE
Keep user on the same page when user authenticates

### DIFF
--- a/assets/typescript/list/index.ts
+++ b/assets/typescript/list/index.ts
@@ -21,7 +21,7 @@ if (mapElement !== null) {
   );
   map.addLayer(baselayer);
 
-  fetch(`/api/region/${region}.geojson`)
+  fetch(`/api/region/${region}.geojson`, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
     .then(response => response.json())
     .then(geojson => {
       const layer = new GeoJSON(geojson);
@@ -67,7 +67,7 @@ if (chartElement !== null) {
   const chart = new ApexCharts(chartElement, options);
   chart.render();
 
-  fetch(`/api/region/${region}/count.json`)
+  fetch(`/api/region/${region}/count.json`, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
     .then(response => response.json())
     .then(json => {
       const series: ApexAxisChartSeries = [

--- a/src/EventSubscriber/RequestSubscriber.php
+++ b/src/EventSubscriber/RequestSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
+
+/**
+ * @see https://symfony.com/doc/current/security/form_login_setup.html#redirecting-to-the-last-accessed-page-with-targetpathtrait
+ */
+class RequestSubscriber implements EventSubscriberInterface
+{
+    use TargetPathTrait;
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+        if (
+            true !== $event->isMainRequest()
+            || true === $request->isXmlHttpRequest()
+            || 'connect_openstreetmap_start' === $request->attributes->get('_route')
+        ) {
+            return;
+        }
+
+        $this->saveTargetPath($request->getSession(), 'main', $request->getUri());
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest'],
+        ];
+    }
+}

--- a/src/Security/OpenStreetMapAuthenticator.php
+++ b/src/Security/OpenStreetMapAuthenticator.php
@@ -16,9 +16,12 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
 
 class OpenStreetMapAuthenticator extends OAuth2Authenticator
 {
+    use TargetPathTrait;
+
     public function __construct(
         private ClientRegistry $clientRegistry,
         private EntityManagerInterface $entityManager,
@@ -61,12 +64,10 @@ class OpenStreetMapAuthenticator extends OAuth2Authenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        $targetUrl = $this->router->generate('app_home');
+        // $targetUrl = $this->router->generate('app_home');
+        $targetUrl = $this->getTargetPath($request->getSession(), 'main');
 
         return new RedirectResponse($targetUrl);
-
-        // or, on success, let the request continue to be handled by the controller
-        //return null;
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response


### PR DESCRIPTION
See https://symfony.com/doc/current/security/form_login_setup.html#redirecting-to-the-last-accessed-page-with-targetpathtrait

To be able to use [`$request->isXmlHttpRequest()`](https://github.com/symfony/symfony/blob/499af8da2e66a25014f3dd6c34b2f93b20bf0f2b/src/Symfony/Component/HttpFoundation/Request.php#L1763) to exclude API requests, we need to set the `X-Requested-With` header.