### PR TITLE
Add prev/next button on mapper page

### DIFF
--- a/src/Controller/App/MapperController.php
+++ b/src/Controller/App/MapperController.php
@@ -76,7 +76,7 @@ class MapperController extends AbstractController
 
         $current = array_search($mapper, $mappers, true);
         $prev = $current > 0 ? $mappers[$current - 1] : null;
-        $next = $current < (count($mappers) - 1) ? $mappers[$current + 1] : null;
+        $next = $current < (\count($mappers) - 1) ? $mappers[$current + 1] : null;
 
         return $this->render('app/mapper/index.html.twig', [
             'region' => $region,

--- a/src/Controller/App/MapperController.php
+++ b/src/Controller/App/MapperController.php
@@ -9,6 +9,7 @@ use App\Entity\Welcome;
 use App\Service\RegionsProvider;
 use App\Service\TemplatesProvider;
 use DateTime;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -62,9 +63,26 @@ class MapperController extends AbstractController
             return $this->redirectToRoute('app_mapper', ['regionKey' => $regionKey, 'id' => $this->mapper->getId()]);
         }
 
+        // Prev/Next mapper
+        /** @var Mapper[] */
+        $mappers = $this->getDoctrine()
+            ->getRepository(Mapper::class)
+            ->findBy(['region' => $regionKey]);
+
+        $firstChangetsetCreatedAt = array_map(function (Mapper $mapper): ?DateTimeImmutable {
+            return $mapper->getFirstChangeset()->getCreatedAt();
+        }, $mappers);
+        array_multisort($firstChangetsetCreatedAt, \SORT_DESC, $mappers);
+
+        $current = array_search($mapper, $mappers, true);
+        $prev = $current > 0 ? $mappers[$current - 1] : null;
+        $next = $current < (count($mappers) - 1) ? $mappers[$current + 1] : null;
+
         return $this->render('app/mapper/index.html.twig', [
             'region' => $region,
             'mapper' => $this->mapper,
+            'prev_mapper' => $prev,
+            'next_mapper' => $next,
             'changesets' => $this->mapper->getChangesets(),
             'formNote' => $formNote->createView(),
             'templates' => $this->templates,

--- a/templates/app/mapper/header.html.twig
+++ b/templates/app/mapper/header.html.twig
@@ -20,16 +20,41 @@
             </p>
         </div>
     </div>
-    <div
-        class="mt-6 flex flex-col-reverse justify-stretch space-y-4 space-y-reverse sm:flex-row-reverse sm:justify-end sm:space-x-reverse sm:space-y-0 sm:space-x-3 md:mt-0 md:flex-row md:space-x-3">
+    <div class="mt-6 flex flex-col-reverse justify-stretch space-y-4 space-y-reverse sm:flex-row-reverse sm:justify-end sm:space-x-reverse sm:space-y-0 sm:space-x-3 md:mt-0 md:flex-row md:space-x-3">
         <a class="inline-flex items-center justify-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
             target="_blank" href="https://www.openstreetmap.org/user/{{ mapper.displayName }}">
             {{ 'Profile'|trans }}
         </a>
         <a class="inline-flex items-center justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-blue-500"
-            title="How did you contribute to OpenStreetMap?"
-            target="_blank" href="https://hdyc.neis-one.org/?{{ mapper.displayName }}">
+            title="How did you contribute to OpenStreetMap?" target="_blank" href="https://hdyc.neis-one.org/?{{ mapper.displayName }}">
             HDYC
         </a>
+
+        <span class="relative z-0 inline-flex shadow-sm rounded-md">
+            <a class="{{ prev_mapper is null ? 'opacity-50 cursor-default' : '' }} relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+                href="{{ prev_mapper is null ? '#' : path('app_mapper', {regionKey: region.key, id: prev_mapper.id}) }}"
+                title="{{ prev_mapper is null ? '' : prev_mapper.displayName }}">
+                <span class="sr-only">{{ 'Previous mapper'|trans }}</span>
+                <!-- Heroicon name: solid/chevron-left -->
+                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                    aria-hidden="true">
+                    <path fill-rule="evenodd"
+                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                        clip-rule="evenodd" />
+                </svg>
+            </a>
+            <a class="-ml-px {{ next_mapper is null ? 'opacity-50 cursor-default' : '' }} relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+                href="{{ next_mapper is null ? '#' : path('app_mapper', {regionKey: region.key, id: next_mapper.id}) }}"
+                title="{{ next_mapper is null ? '' : next_mapper.displayName }}">
+                <span class="sr-only">{{ 'Next mapper'|trans }}</span>
+                <!-- Heroicon name: solid/chevron-right -->
+                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                    aria-hidden="true">
+                    <path fill-rule="evenodd"
+                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                        clip-rule="evenodd" />
+                </svg>
+            </a>
+        </span>
     </div>
 </div>

--- a/templates/app/mapper/index.html.twig
+++ b/templates/app/mapper/index.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-{{ include('app/mapper/header.html.twig', {mapper}, with_context=false) }}
+{{ include('app/mapper/header.html.twig', {region, mapper, prev_mapper, next_mapper}, with_context=false) }}
 
 <div class="mt-8 max-w-3xl mx-auto grid grid-cols-1 gap-6 lg:max-w-7xl lg:grid-flow-col-dense lg:grid-cols-3">
     <div class="space-y-6 lg:col-start-1 lg:col-span-2">

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -238,6 +238,14 @@ It helps you discover new mappers in your region and welcome them.</source>
         <source>Developed by {osmbe_link_start}OpenStreetMap Belgium{link_end} and supported by the {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.</source>
         <target>Developed by {osmbe_link_start}OpenStreetMap Belgium{link_end} and supported by the {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.</target>
       </trans-unit>
+      <trans-unit id="YIax95J" resname="Previous mapper">
+        <source>Previous mapper</source>
+        <target>Previous mapper</target>
+      </trans-unit>
+      <trans-unit id="K5yIR1M" resname="Next mapper">
+        <source>Next mapper</source>
+        <target>Next mapper</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages+intl-icu.fr.xlf
+++ b/translations/messages+intl-icu.fr.xlf
@@ -238,6 +238,14 @@ It helps you discover new mappers in your region and welcome them.</source>
         <source>Developed by {osmbe_link_start}OpenStreetMap Belgium{link_end} and supported by the {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.</source>
         <target>Développé par {osmbe_link_start}OpenStreetMap Belgique{link_end} et soutenu par le {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.</target>
       </trans-unit>
+      <trans-unit id="YIax95J" resname="Previous mapper">
+        <source>Previous mapper</source>
+        <target>Cartographe précédent</target>
+      </trans-unit>
+      <trans-unit id="K5yIR1M" resname="Next mapper">
+        <source>Next mapper</source>
+        <target>Cartographe suivant</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages+intl-icu.it.xlf
+++ b/translations/messages+intl-icu.it.xlf
@@ -238,6 +238,14 @@ It helps you discover new mappers in your region and welcome them.</source>
         <source>Developed by {osmbe_link_start}OpenStreetMap Belgium{link_end} and supported by the {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.</source>
         <target>Sviluppato da {osmbe_link_start}OpenStreetMap Belgio{link_end} e supportato dal {lccwg_link_start}Gruppo di lavoro Capitoli Locali e Comunità{link_end}.</target>
       </trans-unit>
+      <trans-unit id="YIax95J" resname="Previous mapper">
+        <source>Previous mapper</source>
+        <target>__Previous mapper</target>
+      </trans-unit>
+      <trans-unit id="K5yIR1M" resname="Next mapper">
+        <source>Next mapper</source>
+        <target>__Next mapper</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages+intl-icu.nl.xlf
+++ b/translations/messages+intl-icu.nl.xlf
@@ -238,6 +238,14 @@ It helps you discover new mappers in your region and welcome them.</source>
         <source>Developed by {osmbe_link_start}OpenStreetMap Belgium{link_end} and supported by the {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.</source>
         <target>Ontwikkeld door {osmbe_link_start}OpenStreetMap Belgium{link_end} met steun van {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.</target>
       </trans-unit>
+      <trans-unit id="YIax95J" resname="Previous mapper">
+        <source>Previous mapper</source>
+        <target>__Previous mapper</target>
+      </trans-unit>
+      <trans-unit id="K5yIR1M" resname="Next mapper">
+        <source>Next mapper</source>
+        <target>__Next mapper</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Add "previous mapper" and "next mapper" buttons on mapper page to easily switch from a mapper to another without having to go back to the list.

![image](https://user-images.githubusercontent.com/1150563/139577388-42f19f07-62c0-4c69-91c5-656e2c44ad85.png)

Close #90 