### PR TITLE
Create german

### DIFF
--- a/templates/messages/german
+++ b/templates/messages/german
@@ -1,0 +1,25 @@
+---
+name: Default
+title: Welcome to OpenStreetMap
+---
+
+Hallo {{ mapper.displayName }}
+
+vielen Dank und meine große Anerkennung für Ihren ersten Beitrag zu OpenStreetMap! Ab sofort können Sie sich als Teil der OSM Gemeinschaft in Deutschland betrachten. Ihre Beiträge sind innerhalb weniger Minuten live; möglicherweise müssen Sie Ihren Browser aktualisieren, um Ihren Beitrag zu sehen.
+
+Die OSM-Gemeinschaft kommuniziert untereinander per Du; ich hoffe, das ist in Ordnung für Dich.
+
+Falls Du Fragen hast, wollen wir gerne helfen: Wenn Du denkst, dass etwas kaputt gemacht zu haben, nicht weißt, wie Du etwas Bestimmtes kartieren sollst, oder wenn Du einfach mehr über OpenStreetMap wissen willst, kontaktiere uns!
+
+Hier einige nützliche Vorschläge für den Anfang:
+
+* Ich empfehle, die OSM [wiki-pages] (https://wiki.openstreetmap.org/wiki/DE:Hauptseite?uselang=de) und die [Tipps für Einsteiger](https://wiki.openstreetmap.org/wiki/DE:Beginners%27_guide) zu nutzen.
+* Wenn Du nicht herausfindest, wie Du etwas mit dem Editor deiner Wahl kartieren kannst, ist die schnellste Lösung ein Blick auf [Map Features](https://wiki.openstreetmap.org/wiki/DE:Map_Features) im Wiki.
+* Kompliziertere Fragen kann eine Suche in der [Hilfe-Seite](https://wiki.openstreetmap.org/wiki/DE:Hilfe) beantworten oder man kann konkret im [Forum](https://forum.openstreetmap.org/viewforum.php?id=14) nachfragen.
+* [learnOSM](https://learnosm.org/de/) ist ein guter Ort, um mehr über OSM zu erfahren. Es gibt Anleitungen für die Verwendung des iD-Browser-Editors und des fortgeschritteneren JOSM-Editors.
+* Persönliche Auswertungen kann man in den Karten auf [resultmaps.neis-one.org](http://resultmaps.neis-one.org/) sehen; dort gibt es eine Auswertung für [Mapper in meiner Nähe](http://resultmaps.neis-one.org/oooc?zoom=12&lat=50.11332&lon=8.50445&layers=B0TFFFFFT); Beispiel Raum Frankfurt, die Karte kann man verschieben oder mit dem Regler links oben vergrößern oder verkleinern.
+
+Was sind Deine nächsten OSM-Aufgaben? Es ist immer sinnvoll, die Umgebung zu kartieren. Restaurants, Geschäfte, Straßen, Bürgersteige, Bänke, im Grunde Merkmale, die Dir bekannt sind; Du bist der Experte. 
+
+Auf weitere Kontakte freue ich mich 
+und wünsche viel Spaß beim Mappen und in der OSM-Gemeinschaft!

--- a/templates/messages/germany/de/default.md
+++ b/templates/messages/germany/de/default.md
@@ -13,13 +13,13 @@ Falls Du Fragen hast, wollen wir gerne helfen: Wenn Du denkst, dass etwas kaputt
 
 Hier einige nützliche Vorschläge für den Anfang:
 
-* Ich empfehle, die OSM [wiki-pages] (https://wiki.openstreetmap.org/wiki/DE:Hauptseite?uselang=de) und die [Tipps für Einsteiger](https://wiki.openstreetmap.org/wiki/DE:Beginners%27_guide) zu nutzen.
+* Ich empfehle, die OSM [wiki-pages](https://wiki.openstreetmap.org/wiki/DE:Hauptseite?uselang=de) und die [Tipps für Einsteiger](https://wiki.openstreetmap.org/wiki/DE:Beginners%27_guide) zu nutzen.
 * Wenn Du nicht herausfindest, wie Du etwas mit dem Editor deiner Wahl kartieren kannst, ist die schnellste Lösung ein Blick auf [Map Features](https://wiki.openstreetmap.org/wiki/DE:Map_Features) im Wiki.
 * Kompliziertere Fragen kann eine Suche in der [Hilfe-Seite](https://wiki.openstreetmap.org/wiki/DE:Hilfe) beantworten oder man kann konkret im [Forum](https://forum.openstreetmap.org/viewforum.php?id=14) nachfragen.
 * [learnOSM](https://learnosm.org/de/) ist ein guter Ort, um mehr über OSM zu erfahren. Es gibt Anleitungen für die Verwendung des iD-Browser-Editors und des fortgeschritteneren JOSM-Editors.
 * Persönliche Auswertungen kann man in den Karten auf [resultmaps.neis-one.org](http://resultmaps.neis-one.org/) sehen; dort gibt es eine Auswertung für [Mapper in meiner Nähe](http://resultmaps.neis-one.org/oooc?zoom=12&lat=50.11332&lon=8.50445&layers=B0TFFFFFT); Beispiel Raum Frankfurt, die Karte kann man verschieben oder mit dem Regler links oben vergrößern oder verkleinern.
 
-Was sind Deine nächsten OSM-Aufgaben? Es ist immer sinnvoll, die Umgebung zu kartieren. Restaurants, Geschäfte, Straßen, Bürgersteige, Bänke, im Grunde Merkmale, die Dir bekannt sind; Du bist der Experte. 
+Was sind Deine nächsten OSM-Aufgaben? Es ist immer sinnvoll, die Umgebung zu kartieren. Restaurants, Geschäfte, Straßen, Bürgersteige, Bänke, im Grunde Merkmale, die Dir bekannt sind; Du bist der Experte.
 
-Auf weitere Kontakte freue ich mich 
+Auf weitere Kontakte freue ich mich
 und wünsche viel Spaß beim Mappen und in der OSM-Gemeinschaft!


### PR DESCRIPTION
This text is based on the "Washington"-version; I'd be pleased, if someone could check and improve this version. 

I used german pages to OSM and reduced some parts that are only available in English language. 

This brings me to a proposal: May be, it's possible to combine the URLs into the "OSM-World" somewhere for different languages, here EN and DE:
[Mainpage](https://wiki.openstreetmap.org/wiki/Main_Page) | [Hauptseite](https://wiki.openstreetmap.org/wiki/DE:Hauptseite?uselang=de)  
[Get Help](https://wiki.openstreetmap.org/wiki/Get_help) | [Hilfe](https://wiki.openstreetmap.org/wiki/DE:Hilfe)
Forum | Forum
...