### PR TITLE
add Discourse group and Telegram group to Italian and English message…

### DIFF
--- a/templates/messages/italy/en/default.md
+++ b/templates/messages/italy/en/default.md
@@ -13,7 +13,7 @@ If your contribution is sporadic, it doesn't matter! Maybe you know someone arou
 
 In addition to contributing to the map, you can help us by, for example, uploading GPS tracks, reporting errors, or promoting OpenStreetMap.
 
-If you want to ask something, or just share your experience or ideas for improvement, we'll be happy to meet you on the Italian mappers mailing list, [talk-it](https://lists.openstreetmap.org/listinfo/talk-it). 
+If you want to ask something, or just share your experience or ideas for improvement, we'll be happy to meet you on the [official group](https://community.openstreetmap.org/c/communities/it/60) , on the [Telegram group](https://telegram.me/OpenStreetMapItalia) or on the Italian mappers mailing list, [talk-it](https://lists.openstreetmap.org/listinfo/talk-it). For other contact channels, please see [Wiki](https://wiki.openstreetmap.org/wiki/IT:Contact).
 
 Find out more about the [Italian community](https://wiki.openstreetmap.org/wiki/Italy).
 

--- a/templates/messages/italy/it/default.md
+++ b/templates/messages/italy/it/default.md
@@ -13,7 +13,7 @@ Se invece il tuo è un contributo sporadico, non importa! Forse conosci qualcuno
 
 Oltre a contribuire alla mappa, puoi aiutarci, ad esempio, caricando tracciati GPS, segnalando errori o promuovendo OpenStreetMap.
 
-Se vuoi chiedere qualcosa, o semplicemente condividere la tua esperienza o idee per migliorare, saremo felici di incontrarti nella mailing list dei mappatori italiani, [talk-it](https://lists.openstreetmap.org/listinfo/talk-it). 
+Se vuoi chiedere qualcosa, o semplicemente condividere la tua esperienza o idee per migliorare, saremo felici di incontrarti nel [gruppo ufficiale](https://community.openstreetmap.org/c/communities/it/60) , in quello [Telegram](https://telegram.me/OpenStreetMapItalia) oppure  nella mailing list dei mappatori italiani, [talk-it](https://lists.openstreetmap.org/listinfo/talk-it). Per altri canali consulta la [Wiki](https://wiki.openstreetmap.org/wiki/IT:Contact).
 
 Scopri maggiori informazioni sulla [comunità italiana](https://wiki.openstreetmap.org/wiki/Italy).
 


### PR DESCRIPTION
As discussed on the Italian Telegram group, the mailing list could be less appealing to new users, hence the addition of the other contact channels.