### PR TITLE
Do not try to fetch deleted users + Make chunks

### DIFF
--- a/src/Command/NewMapperCommand.php
+++ b/src/Command/NewMapperCommand.php
@@ -85,10 +85,7 @@ class NewMapperCommand extends Command
             $changesetsCollection = $changesetsResponse->toArray();
 
             $path = 'var/users_deleted.txt';
-            if (!file_exists($path)) {
-                $filesystem = new Filesystem();
-                $filesystem->dumpFile($path, $this->osm->getDeletedUsers()->getContent());
-            }
+            (new Filesystem())->dumpFile($path, $this->osm->getDeletedUsers()->getContent());
             $usersDeleted = array_map(fn ($line) => (int) trim($line), file($path, \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES));
 
             $features = array_filter($changesetsCollection['features'], fn (array $feature) => !\in_array((int) $feature['properties']['uid'], $usersDeleted, true));

--- a/src/Command/NewMapperCommand.php
+++ b/src/Command/NewMapperCommand.php
@@ -89,7 +89,7 @@ class NewMapperCommand extends Command
                 $filesystem = new Filesystem();
                 $filesystem->dumpFile($path, $this->osm->getDeletedUsers()->getContent());
             }
-            $usersDeleted = array_map(fn ($line) => (int) (trim($line)), file($path, \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES));
+            $usersDeleted = array_map(fn ($line) => (int) trim($line), file($path, \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES));
 
             $features = array_filter($changesetsCollection['features'], fn (array $feature) => !\in_array((int) $feature['properties']['uid'], $usersDeleted, true));
 

--- a/src/Command/NewMapperCommand.php
+++ b/src/Command/NewMapperCommand.php
@@ -89,9 +89,9 @@ class NewMapperCommand extends Command
                 $filesystem = new Filesystem();
                 $filesystem->dumpFile($path, $this->osm->getDeletedUsers()->getContent());
             }
-            $usersDeleted = array_map(fn ($line) => intval(trim($line)), file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES));
+            $usersDeleted = array_map(fn ($line) => (int) (trim($line)), file($path, \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES));
 
-            $features = array_filter($changesetsCollection['features'], fn (array $feature) => !in_array((int) $feature['properties']['uid'], $usersDeleted, true));
+            $features = array_filter($changesetsCollection['features'], fn (array $feature) => !\in_array((int) $feature['properties']['uid'], $usersDeleted, true));
 
             $usersId = array_map(fn (array $feature) => (int) $feature['properties']['uid'], $features);
 

--- a/src/Service/OpenStreetMapAPI.php
+++ b/src/Service/OpenStreetMapAPI.php
@@ -8,7 +8,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 class OpenStreetMapAPI
 {
     public function __construct(
-        private HttpClientInterface $osmClient
+        private HttpClientInterface $osmClient,
+        private HttpClientInterface $client
     ) {
     }
 
@@ -26,7 +27,17 @@ class OpenStreetMapAPI
     {
         $response = $this->osmClient->request(
             'GET',
-            sprintf('changesets.xml?%s', http_build_query(['user' => $id])),
+            sprintf('changesets.xml?%s', http_build_query(['user' => $id]))
+        );
+
+        return $response;
+    }
+
+    public function getDeletedUsers(): ResponseInterface
+    {
+        $response = $this->client->request(
+            'GET',
+            'https://planet.openstreetmap.org/users_deleted/users_deleted.txt'
         );
 
         return $response;


### PR DESCRIPTION
This PR should fix 2 issues:

- Make chunks of 50 users when requesting users details.
- Request returned 404 when trying to get details of a (meanwhile) deleted user, so we now filter out all changesets coming from OSMCha related to a deleted user