### PR TITLE
Remove references to old forum in templates

### DIFF
--- a/templates/messages/germany/de/default_JOSM.md
+++ b/templates/messages/germany/de/default_JOSM.md
@@ -15,7 +15,7 @@ Hier einige nützliche Vorschläge für den Anfang:
 
 * Ich empfehle, die OSM [wiki-pages](https://wiki.openstreetmap.org/wiki/DE:Hauptseite?uselang=de) und die [Tipps für Einsteiger](https://wiki.openstreetmap.org/wiki/DE:Beginners%27_guide) zu nutzen.
 * Wenn Du nicht herausfindest, wie Du etwas mit dem Editor deiner Wahl kartieren kannst, ist die schnellste Lösung ein Blick auf [Map Features](https://wiki.openstreetmap.org/wiki/DE:Map_Features) im Wiki.
-* Kompliziertere Fragen kann eine Suche in der [Hilfe-Seite](https://wiki.openstreetmap.org/wiki/DE:Hilfe) beantworten oder man kann konkret im [Forum](https://forum.openstreetmap.org/viewforum.php?id=14) nachfragen.
+* Kompliziertere Fragen kann eine Suche in der [Hilfe-Seite](https://wiki.openstreetmap.org/wiki/DE:Hilfe) beantworten oder man kann konkret im [Forum](https://community.openstreetmap.org/c/communities/de/56) nachfragen.
 * [learnOSM](https://learnosm.org/de/) ist ein guter Ort, um mehr über OSM zu erfahren. Es gibt Anleitungen für die Verwendung des iD-Browser-Editors und des fortgeschritteneren JOSM-Editors.
 * Persönliche Auswertungen kann man in den Karten auf [resultmaps.neis-one.org](https://resultmaps.neis-one.org/) sehen; dort gibt es eine Auswertung für [Mapper in meiner Nähe](https://resultmaps.neis-one.org/oooc?zoom=12&lat=50.11332&lon=8.50445&layers=B0TFFFFFT); Beispiel Raum Frankfurt, die Karte kann man verschieben oder mit dem Regler links oben vergrößern oder verkleinern.
 

--- a/templates/messages/ireland/en/default.md
+++ b/templates/messages/ireland/en/default.md
@@ -13,7 +13,7 @@ If you've got any questions, we can help you: if you don't know for sure how to 
 
 - **Website** Visit us at [openstreetmap.ie](https://openstreetmap.ie)
 - **Mailing list** Sign up for the mailing list [talk-ie@openstreetmap](https://lists.openstreetmap.org/listinfo/talk-ie)
-- **Forum** Ireland sub-forum in the [OpenStreetMap Forums](https://forum.openstreetmap.org/viewforum.php?id=34)
+- **Forum** Ireland sub-forum in the [OpenStreetMap Forums](https://community.openstreetmap.org/c/communities/ie/54)
 - **Twitter** Twitter user > [@osm_ie](https://twitter.com/osm_ie)
 - **Facebook** Facebook group > [OpenStreetMap Ireland](https://www.facebook.com/groups/OpenStreetMapIreland/)
 - **Telegram** [OpenStreetMap > Ireland](https://t.me/+d7GLr3OVUGgyYWIy)

--- a/templates/messages/poland/pl/default.md
+++ b/templates/messages/poland/pl/default.md
@@ -7,7 +7,7 @@ Cześć {{ mapper.displayName }}!
 
 Dziękuję za Twój wkład w ulepszenie mapy — i witaj w polskiej społeczności OpenStreetMap! Jeśli masz jakieś pytania lub po prostu chcesz pogadać, znajdziesz nas na:
 
-* [polskim forum](https://forum.openstreetmap.org/viewforum.php?id=23),
+* [polskim forum](https://community.openstreetmap.org/c/communities/pl/40),
 * [grupie na Facebooku](https://www.facebook.com/groups/osmpolska),
 * [czacie Discord](https://openstreetmap.org.pl/discord) — oprócz bieżących rozmów, co piątek po 19 spotykamy się na kanale głosowym.
 


### PR DESCRIPTION
This PR updates references to sub-forums on [forum.osm.org](https://forum.openstreetmap.org) with their replacements on [community.osm.org](https://community.osm.org)

[As of October 6th](https://community.openstreetmap.org/t/forum-osm-org-transition-announcement/2361/52), users are no longer able to create new threads on the old forum
