### PR TITLE
fix(config/services.yaml): sort langcode by alphabet order

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,7 +7,7 @@ parameters:
     osmcha.api.url: 'https://osmcha.org/api/v1/'
     osmcha.api.key: '%env(OSMCHA_API_KEY)%'
     osm.api.url: 'https://api.openstreetmap.org/api/0.6/'
-    app.locales: ['en','fr','it','nl','bg','es_ES','ja','pl','de','sq','zh_TW','zh_CN','hu']
+    app.locales: ['bg','de','en','es_ES','fr','hu','it','ja','nl','pl','sq','zh_CN','zh_TW']
     app.userAgent: 'OpenStreetMap Welcome Tool'
     app.title: 'OpenStreetMap Welcome Tool'
 


### PR DESCRIPTION
Recently I noticed that Hungarian was added to welcome tool, and realised that languages' order in footer just like "queue.push" 

https://github.com/osmbe/osm-welcome-tool/blob/a6de209f8440bdcb862107a851b1d4710b215bba/config/services.yaml#L10

![图片](https://user-images.githubusercontent.com/42690037/202860634-ddd7e4b5-9bcd-43be-a538-50e23b8b0a4e.png)

While another place they are sorted by alphabet order

https://github.com/osmbe/osm-welcome-tool/blob/a6de209f8440bdcb862107a851b1d4710b215bba/assets/typescript/list/index.ts#L4-L16

There maybe some unconsistency, so I make this tiny change.



