### PR TITLE
Add support for multiple region per new mapper

### DIFF
--- a/migrations/Version20221116194655.php
+++ b/migrations/Version20221116194655.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221116194655 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Migrate to multiple regions per user';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE mapper_region (mapper_id INTEGER NOT NULL, region_id VARCHAR(255) NOT NULL, PRIMARY KEY(mapper_id, region_id), CONSTRAINT FK_6E8B9023B9CA839A FOREIGN KEY (mapper_id) REFERENCES mapper (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT FK_6E8B902398260155 FOREIGN KEY (region_id) REFERENCES region (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE)');
+        $this->addSql('CREATE INDEX IDX_6E8B9023B9CA839A ON mapper_region (mapper_id)');
+        $this->addSql('CREATE INDEX IDX_6E8B902398260155 ON mapper_region (region_id)');
+        $this->addSql('CREATE TEMPORARY TABLE __temp__mapper AS SELECT id, region, display_name, account_created, changesets_count, status, image FROM mapper');
+        $this->addSql('DROP TABLE mapper');
+        $this->addSql('CREATE TABLE mapper (id INTEGER NOT NULL, display_name VARCHAR(255) NOT NULL, account_created DATETIME NOT NULL, changesets_count INTEGER NOT NULL, status VARCHAR(255) NOT NULL, image CLOB DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('INSERT INTO mapper (id, display_name, account_created, changesets_count, status, image) SELECT id, display_name, account_created, changesets_count, status, image FROM __temp__mapper');
+        $this->addSql('INSERT INTO mapper_region (mapper_id, region_id) SELECT id, region FROM __temp__mapper');
+        $this->addSql('DROP TABLE __temp__mapper');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE TEMPORARY TABLE __temp__mapper_region AS SELECT mapper_id, region_id FROM mapper_region');
+        $this->addSql('DROP TABLE mapper_region');
+        $this->addSql('CREATE TEMPORARY TABLE __temp__mapper AS SELECT id, display_name, account_created, changesets_count, status, image FROM mapper');
+        $this->addSql('DROP TABLE mapper');
+        $this->addSql('CREATE TABLE mapper (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, display_name VARCHAR(255) NOT NULL, account_created DATETIME NOT NULL, changesets_count INTEGER NOT NULL, status VARCHAR(255) NOT NULL, image CLOB DEFAULT NULL, region VARCHAR(255) NOT NULL)');
+        $this->addSql('INSERT INTO mapper (id, display_name, account_created, changesets_count, status, image, region) SELECT m.id, m.display_name, m.account_created, m.changesets_count, m.status, m.image, mr.region_id FROM __temp__mapper m LEFT JOIN (SELECT mapper_id, region_id FROM __temp__mapper_region mr GROUP BY 1) mr ON m.id = mr.mapper_id');
+        $this->addSql('DROP TABLE __temp__mapper');
+        $this->addSql('DROP TABLE __temp__mapper_region');
+    }
+}

--- a/src/Command/NewMapperCommand.php
+++ b/src/Command/NewMapperCommand.php
@@ -200,8 +200,18 @@ class NewMapperCommand extends Command
 
             /** @var Mapper[] */
             $mappers = array_map(function (array $array) use ($key): Mapper {
+                $region = $this->regionsProvider->getEntity($key);
+
+                if (is_null($region)) {
+                    $region = new Region();
+                    $region->setId($key);
+                    $region->setLastUpdate(new \DateTime('1970-01-01'));
+
+                    $this->entityManager->persist($region);
+                }
+
                 $mapper = $this->mapperProvider->fromOSM($array);
-                $mapper->setRegion($key);
+                $mapper->addRegion($region);
 
                 return $mapper;
             }, $usersArray['users']);

--- a/src/Command/NewMapperCommand.php
+++ b/src/Command/NewMapperCommand.php
@@ -202,7 +202,7 @@ class NewMapperCommand extends Command
             $mappers = array_map(function (array $array) use ($key): Mapper {
                 $region = $this->regionsProvider->getEntity($key);
 
-                if (is_null($region)) {
+                if (null === $region) {
                     $region = new Region();
                     $region->setId($key);
                     $region->setLastUpdate(new \DateTime('1970-01-01'));

--- a/src/Controller/API/RegionController.php
+++ b/src/Controller/API/RegionController.php
@@ -34,7 +34,8 @@ class RegionController extends AbstractController
     #[Route('/api/region/{continent}/{regionKey}/count.{_format}', name: 'api_region_count', format: 'json', requirements: ['_format' => 'json'])]
     public function count(string $continent, string $regionKey): Response
     {
-        $mappers = $this->mapperRepository->findBy(['region' => $regionKey]);
+        $region = $this->provider->getEntity($regionKey);
+        $mappers = is_null($region) ? [] : $region->getMappers()->toArray();
 
         $count = [];
         foreach ($mappers as $mapper) {

--- a/src/Controller/API/RegionController.php
+++ b/src/Controller/API/RegionController.php
@@ -35,7 +35,7 @@ class RegionController extends AbstractController
     public function count(string $continent, string $regionKey): Response
     {
         $region = $this->provider->getEntity($regionKey);
-        $mappers = is_null($region) ? [] : $region->getMappers()->toArray();
+        $mappers = null === $region ? [] : $region->getMappers()->toArray();
 
         $count = [];
         foreach ($mappers as $mapper) {

--- a/src/Controller/App/HomeController.php
+++ b/src/Controller/App/HomeController.php
@@ -21,7 +21,7 @@ class HomeController extends AbstractController
 
         foreach ($regions as $continent => &$group) {
             foreach ($group as $key => &$region) {
-                $region['lastUpdate'] = $this->provider->getLastUpdate($key);
+                $region['lastUpdate'] = $this->provider->getEntity($key)?->getLastUpdate();
                 $region['count'] = $this->provider->getPercentage($key);
             }
         }

--- a/src/Controller/App/ListController.php
+++ b/src/Controller/App/ListController.php
@@ -28,7 +28,8 @@ class ListController extends AbstractController
     public function index(string $regionKey, ?string $continent, ?int $year = null, ?int $month = null): Response
     {
         $region = $this->provider->getRegion($continent, $regionKey);
-        $region['lastUpdate'] = $this->provider->getLastUpdate($regionKey);
+        $regionEntity = $this->provider->getEntity($regionKey);
+        $region['lastUpdate'] = is_null($regionEntity) ? null : $regionEntity->getLastUpdate();
         $region['count'] = $this->provider->getPercentage($regionKey);
 
         if (null === $year && null === $month) {
@@ -48,25 +49,24 @@ class ListController extends AbstractController
             return $this->redirectToRoute('app_list_full', ['continent' => $region['continent'], 'regionKey' => $region['key'], 'year' => $year, 'month' => $month]);
         }
 
-        /** @var Mapper[] */
-        $mappers = $this->entityManager
-            ->getRepository(Mapper::class)
-            ->findBy(['region' => $regionKey]);
+        $mappers = is_null($regionEntity) ? [] : $regionEntity->getMappers()->toArray();
 
-        $firstChangetsetCreatedAt = array_map(fn (Mapper $mapper): ?\DateTimeImmutable => $mapper->getFirstChangeset()->getCreatedAt(), $mappers);
-        array_multisort($firstChangetsetCreatedAt, \SORT_DESC, $mappers);
+        if (count($mappers) > 0) {
+            $firstChangetsetCreatedAt = array_map(fn (Mapper $mapper): ?\DateTimeImmutable => $mapper->getFirstChangeset()->getCreatedAt(), $mappers);
+            array_multisort($firstChangetsetCreatedAt, \SORT_DESC, $mappers);
 
-        $month = (new \DateTime())->setDate($year, $month, 1);
+            $month = (new \DateTime())->setDate($year, $month, 1);
 
-        $mappers = array_filter(
-            $mappers,
-            function (Mapper $mapper) use ($month): bool {
-                /** @var \DateTimeImmutable */
-                $createdAt = $mapper->getFirstChangeset()->getCreatedAt();
+            $mappers = array_filter(
+                $mappers,
+                function (Mapper $mapper) use ($month): bool {
+                    /** @var \DateTimeImmutable */
+                    $createdAt = $mapper->getFirstChangeset()->getCreatedAt();
 
-                return $createdAt->format('Ym') === $month->format('Ym');
-            }
-        );
+                    return $createdAt->format('Ym') === $month->format('Ym');
+                }
+            );
+        }
 
         return $this->render('app/list/index.html.twig', [
             'region' => $region,

--- a/src/Controller/App/ListController.php
+++ b/src/Controller/App/ListController.php
@@ -29,7 +29,7 @@ class ListController extends AbstractController
     {
         $region = $this->provider->getRegion($continent, $regionKey);
         $regionEntity = $this->provider->getEntity($regionKey);
-        $region['lastUpdate'] = is_null($regionEntity) ? null : $regionEntity->getLastUpdate();
+        $region['lastUpdate'] = null === $regionEntity ? null : $regionEntity->getLastUpdate();
         $region['count'] = $this->provider->getPercentage($regionKey);
 
         if (null === $year && null === $month) {
@@ -49,9 +49,9 @@ class ListController extends AbstractController
             return $this->redirectToRoute('app_list_full', ['continent' => $region['continent'], 'regionKey' => $region['key'], 'year' => $year, 'month' => $month]);
         }
 
-        $mappers = is_null($regionEntity) ? [] : $regionEntity->getMappers()->toArray();
+        $mappers = null === $regionEntity ? [] : $regionEntity->getMappers()->toArray();
 
-        if (count($mappers) > 0) {
+        if (\count($mappers) > 0) {
             $firstChangetsetCreatedAt = array_map(fn (Mapper $mapper): ?\DateTimeImmutable => $mapper->getFirstChangeset()->getCreatedAt(), $mappers);
             array_multisort($firstChangetsetCreatedAt, \SORT_DESC, $mappers);
 

--- a/src/Controller/App/MapperController.php
+++ b/src/Controller/App/MapperController.php
@@ -4,6 +4,7 @@ namespace App\Controller\App;
 
 use App\Entity\Mapper;
 use App\Entity\Note;
+use App\Entity\Region;
 use App\Entity\Template;
 use App\Entity\Welcome;
 use App\Service\RegionsProvider;
@@ -31,13 +32,20 @@ class MapperController extends AbstractController
     ) {
     }
 
-    #[Route('/mapper/{id}', name: 'app_mapper')]
+    #[Route('/{regionKey}/mapper/{id}', name: 'app_mapper', requirements: ['regionKey' => '[\w\-_]+'])]
+    #[Route('/{continent}/{regionKey}/mapper/{id}', name: 'app_mapper_full', requirements: ['continent' => 'asia|africa|australia|europe|north-america|south-america', 'regionKey' => '[\w\-_]+'])]
     #[IsGranted('ROLE_USER')]
-    public function index(Request $request, Mapper $mapper): Response
+    public function index(Request $request, Mapper $mapper, string $regionKey, ?string $continent): Response
     {
+        $region = $this->provider->getRegion($continent, $regionKey);
+
         $this->mapper = $mapper;
 
-        $region = $this->provider->getRegion(null, $this->mapper->getRegion());
+        $mapperRegions = array_map(fn (Region $region) => $region->getId(), $this->mapper->getRegion()->toArray());
+
+        if (!in_array($regionKey, $mapperRegions, true)) {
+            throw $this->createNotFoundException('This mapper was not detected in this region.');
+        }
 
         // Welcome
         if ($request->query->has('welcome')) {
@@ -63,9 +71,7 @@ class MapperController extends AbstractController
 
         // Prev/Next mapper
         /** @var Mapper[] */
-        $mappers = $this->entityManager
-            ->getRepository(Mapper::class)
-            ->findBy(['region' => $region['key']]);
+        $mappers = $this->provider->getEntity($regionKey)?->getMappers()->toArray() ?? [];
 
         $firstChangetsetCreatedAt = array_map(fn (Mapper $mapper): ?\DateTimeImmutable => $mapper->getFirstChangeset()->getCreatedAt(), $mappers);
         array_multisort($firstChangetsetCreatedAt, \SORT_DESC, $mappers);

--- a/src/Controller/App/MapperController.php
+++ b/src/Controller/App/MapperController.php
@@ -43,7 +43,7 @@ class MapperController extends AbstractController
 
         $mapperRegions = array_map(fn (Region $region) => $region->getId(), $this->mapper->getRegion()->toArray());
 
-        if (!in_array($regionKey, $mapperRegions, true)) {
+        if (!\in_array($regionKey, $mapperRegions, true)) {
             throw $this->createNotFoundException('This mapper was not detected in this region.');
         }
 

--- a/src/Entity/Mapper.php
+++ b/src/Entity/Mapper.php
@@ -15,9 +15,6 @@ class Mapper
     private $id;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $region;
-
-    #[ORM\Column(type: 'string', length: 255)]
     private $display_name;
 
     #[ORM\Column(type: 'datetime')]
@@ -41,10 +38,14 @@ class Mapper
     #[ORM\OneToOne(targetEntity: Welcome::class, mappedBy: 'mapper', cascade: ['persist'])]
     private $welcome;
 
+    #[ORM\ManyToMany(targetEntity: Region::class, inversedBy: 'mappers')]
+    private Collection $region;
+
     public function __construct()
     {
         $this->changesets = new ArrayCollection();
         $this->notes = new ArrayCollection();
+        $this->region = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -55,18 +56,6 @@ class Mapper
     public function setId(int $id): self
     {
         $this->id = $id;
-
-        return $this;
-    }
-
-    public function getRegion(): ?string
-    {
-        return $this->region;
-    }
-
-    public function setRegion(string $region): self
-    {
-        $this->region = $region;
 
         return $this;
     }
@@ -217,6 +206,30 @@ class Mapper
         }
 
         $this->welcome = $welcome;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, region>
+     */
+    public function getRegion(): Collection
+    {
+        return $this->region;
+    }
+
+    public function addRegion(region $region): self
+    {
+        if (!$this->region->contains($region)) {
+            $this->region->add($region);
+        }
+
+        return $this;
+    }
+
+    public function removeRegion(region $region): self
+    {
+        $this->region->removeElement($region);
 
         return $this;
     }

--- a/src/Entity/Region.php
+++ b/src/Entity/Region.php
@@ -3,6 +3,8 @@
 namespace App\Entity;
 
 use App\Repository\RegionRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: RegionRepository::class)]
@@ -14,6 +16,14 @@ class Region
 
     #[ORM\Column(type: 'datetime')]
     private $lastUpdate;
+
+    #[ORM\ManyToMany(targetEntity: Mapper::class, mappedBy: 'region')]
+    private Collection $mappers;
+
+    public function __construct()
+    {
+        $this->mappers = new ArrayCollection();
+    }
 
     public function getId(): ?string
     {
@@ -35,6 +45,33 @@ class Region
     public function setLastUpdate(\DateTime $lastUpdate): self
     {
         $this->lastUpdate = $lastUpdate;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Mapper>
+     */
+    public function getMappers(): Collection
+    {
+        return $this->mappers;
+    }
+
+    public function addMapper(Mapper $mapper): self
+    {
+        if (!$this->mappers->contains($mapper)) {
+            $this->mappers->add($mapper);
+            $mapper->addRegion($this);
+        }
+
+        return $this;
+    }
+
+    public function removeMapper(Mapper $mapper): self
+    {
+        if ($this->mappers->removeElement($mapper)) {
+            $mapper->removeRegion($this);
+        }
 
         return $this;
     }

--- a/src/Service/RegionsProvider.php
+++ b/src/Service/RegionsProvider.php
@@ -79,7 +79,7 @@ class RegionsProvider
     public function getPercentage(string $key): array
     {
         $region = $this->getEntity($key);
-        $mappers = is_null($region) ? [] : $region->getMappers()->toArray();
+        $mappers = null === $region ? [] : $region->getMappers()->toArray();
 
         $checked = array_filter($mappers, fn (Mapper $mapper): bool => null !== $mapper->getWelcome() || false === $mapper->getNotes()->isEmpty());
 

--- a/src/Service/RegionsProvider.php
+++ b/src/Service/RegionsProvider.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Entity\Mapper;
+use App\Entity\Region;
 use App\Repository\MapperRepository;
 use App\Repository\RegionRepository;
 use App\Repository\WelcomeRepository;
@@ -70,21 +71,15 @@ class RegionsProvider
         return $data;
     }
 
-    public function getLastUpdate(string $key): ?\DateTime
+    public function getEntity(string $key): ?Region
     {
-        $region = $this->regionRepository->find($key);
-
-        if (null === $region) {
-            return null;
-        }
-
-        return $region->getLastUpdate();
+        return $this->regionRepository->find($key);
     }
 
     public function getPercentage(string $key): array
     {
-        /** @var Mapper[] */
-        $mappers = $this->mapperRepository->findBy(['region' => $key]);
+        $region = $this->getEntity($key);
+        $mappers = is_null($region) ? [] : $region->getMappers()->toArray();
 
         $checked = array_filter($mappers, fn (Mapper $mapper): bool => null !== $mapper->getWelcome() || false === $mapper->getNotes()->isEmpty());
 

--- a/templates/app/breadcrumb.html.twig
+++ b/templates/app/breadcrumb.html.twig
@@ -66,7 +66,7 @@
                         d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
                         clip-rule="evenodd" />
                 </svg>
-                <a href="{{ path('app_mapper', {id: mapper.id}) }}" class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700">{{ 'Mapper'|trans }}</a>
+                <a href="{{ path('app_mapper_full', {continent: region.continent, regionKey: region.key, id: mapper.id}) }}" class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700">{{ 'Mapper'|trans }}</a>
             </div>
         </li>
 

--- a/templates/app/list/table.html.twig
+++ b/templates/app/list/table.html.twig
@@ -32,11 +32,11 @@
         <tbody>
             {% for mapper in mappers %}
 
-            <tr class="{{ loop.index0 % 2 == 0 ? 'bg-white' : 'bg-gray-50' }}">
+            <tr class="{{ loop.index0 % 2 == 0 ? 'bg-white' : 'bg-gray-50' }} {{ mapper.region|length > 3 ? 'opacity-25 hover:opacity-75' }}">
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                     {% if app.user is not null %}
                     <a class="shrink-0 group block"
-                        href="{{ path('app_mapper', {id: mapper.id}) }}">
+                        href="{{ path('app_mapper_full', {continent: region.continent, regionKey: region.key, id: mapper.id}) }}">
                         {{ include('app/list/avatar.html.twig', {mapper}, with_context=false) }}
                     </a>
                     {% else %}

--- a/templates/app/mapper/form.html.twig
+++ b/templates/app/mapper/form.html.twig
@@ -18,7 +18,7 @@
                         <!-- Current: "bg-gray-100 text-gray-900", Default: "text-gray-600 hover:bg-gray-50 hover:text-gray-900" -->
                         {% set active = template == selectedTemplate %}
                         <a class="group flex items-center px-3 py-2 text-sm font-medium rounded-md {{ active ? 'bg-gray-100 text-gray-900' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50' }}"
-                            href="{{ path('app_mapper', {id: mapper.id}) }}?locale={{ template.locale }}&amp;template={{ template.filename }}">
+                            href="{{ path('app_mapper_full', {continent: region.continent, regionKey: region.key, id: mapper.id}) }}?locale={{ template.locale }}&amp;template={{ template.filename }}">
                             <span class="truncate">
                                 {{ template.name }} ({{ template.locale|language_name }})
                             </span>

--- a/templates/app/mapper/header.html.twig
+++ b/templates/app/mapper/header.html.twig
@@ -18,6 +18,9 @@
                 {% set date = mapper.accountCreated|format_date('long') %}
                 {{ 'Mapper since {date}'|trans({'{date}': date}) }}
             </p>
+            <p class="text-sm font-medium text-gray-500">
+                {{ 'Mapper detected in {count} region(s)'|trans({'{count}': mapper.region|length}) }}
+            </p>
         </div>
     </div>
     <div class="mt-6 flex flex-col-reverse justify-stretch space-y-4 space-y-reverse sm:flex-row-reverse sm:justify-end sm:space-x-reverse sm:space-y-0 sm:space-x-3 md:mt-0 md:flex-row md:space-x-3">
@@ -32,7 +35,7 @@
 
         <span class="relative z-0 inline-flex shadow-sm rounded-md">
             <a class="{{ prev_mapper is null ? 'opacity-50 cursor-default' : '' }} relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-                href="{{ prev_mapper is null ? '#' : path('app_mapper', {id: prev_mapper.id}) }}"
+                href="{{ prev_mapper is null ? '#' : path('app_mapper_full', {continent: region.continent, regionKey: region.key, id: prev_mapper.id}) }}"
                 title="{{ prev_mapper is null ? '' : prev_mapper.displayName }}">
                 <span class="sr-only">{{ 'Previous mapper'|trans }}</span>
                 <!-- Heroicon name: solid/chevron-left -->
@@ -44,7 +47,7 @@
                 </svg>
             </a>
             <a class="-ml-px {{ next_mapper is null ? 'opacity-50 cursor-default' : '' }} relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-                href="{{ next_mapper is null ? '#' : path('app_mapper', {id: next_mapper.id}) }}"
+                href="{{ next_mapper is null ? '#' : path('app_mapper_full', {continent: region.continent, regionKey: region.key, id: next_mapper.id}) }}"
                 title="{{ next_mapper is null ? '' : next_mapper.displayName }}">
                 <span class="sr-only">{{ 'Next mapper'|trans }}</span>
                 <!-- Heroicon name: solid/chevron-right -->


### PR DESCRIPTION
A new mapper will now appear in every region it has been detected (instead of just one).  
As soon as someone welcomes the new mapper it will show up in every region.

If a mapper is detected in more than 3 regions it will be displayed as faded in the list, it probably means that the new mapper created a changeset that's really big.