### PR TITLE
Fix ireland flag being ☘️ instead of 🇮🇪

### DIFF
--- a/config/regions.yaml
+++ b/config/regions.yaml
@@ -201,7 +201,7 @@ regions:
       osmcha.id: b874522b-99f2-4ef7-ad1f-b5d27323ca3a
     ireland:
       name: Ireland
-      flag: ☘️
+      flag: 🇮🇪
       osmcha.id: dfa457d9-b30c-4034-baae-04a268408b39
     italy:
       name: Italy


### PR DESCRIPTION
Now, the Ireland flag is not a flag at all, but a clover. This pull request fixes that.