### PR TITLE
💄 Add language selection page

### DIFF
--- a/src/Controller/App/LanguageController.php
+++ b/src/Controller/App/LanguageController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\App;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -11,7 +11,7 @@ final class LanguageController extends AbstractController
     #[Route('/language', name: 'app_language')]
     public function index(): Response
     {
-        return $this->render('home/language.html.twig', [
+        return $this->render('app/home/language.html.twig', [
             'controller_name' => 'LanguageController',
         ]);
     }

--- a/src/Controller/App/LanguageController.php
+++ b/src/Controller/App/LanguageController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class LanguageController extends AbstractController
+{
+    #[Route('/language', name: 'app_language')]
+    public function index(): Response
+    {
+        return $this->render('home/language.html.twig', [
+            'controller_name' => 'LanguageController',
+        ]);
+    }
+}

--- a/templates/app/banner.html.twig
+++ b/templates/app/banner.html.twig
@@ -1,0 +1,11 @@
+<div class="flex-1 min-w-0">
+    <p>
+        {{ 'This is the OpenStreetMap Welcome Tool.\r\nIt helps you discover new mappers in your region and welcome them.'|trans|nl2br }}
+    </p>
+    <p>
+        {{ 'If you want to add your region or your language to the Welcome Tool, check our {contributing_link_start}contributing guide{link_end}.'|trans({'{contributing_link_start}': '<a class="text-indigo-600 hover:text-indigo-900" target="_blank" href="https://github.com/osmbe/osm-welcome-tool/blob/2.x/CONTRIBUTING.md">', '{link_end}': '</a>'})|raw }}
+    </p>
+    <p class="mt-3 text-sm">
+        {{ 'Developed by {osmbe_link_start}OpenStreetMap Belgium{link_end} and supported by the {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.'|trans({'{osmbe_link_start}': '<a class="text-indigo-600 hover:text-indigo-900" target="_blank" href="https://openstreetmap.be/">', '{lccwg_link_start}': '<a class="text-indigo-600 hover:text-indigo-900" target="_blank" href="https://wiki.osmfoundation.org/wiki/Local_Chapters_and_Communities_Working_Group">', '{link_end}': '</a>'})|raw }}
+    </p>
+</div>

--- a/templates/app/footer.html.twig
+++ b/templates/app/footer.html.twig
@@ -9,13 +9,6 @@
                 {{ app.request.locale|locale_name(app.request.locale)|capitalize }}
             </a>
 
-            <!--<div class="divide-solid">
-                {% for locale in welcome.locales %}
-                {% if loop.index0 > 0 %} &bull; {% endif %}
-                <a href="?l={{ locale }}">{{ locale|locale_name(locale)|capitalize }}</a>
-                {% endfor %}
-            </div>-->
-
             <div class="flex items-center gap-2">
                 <div class="flex items-center">
                     <img class="h-4 mr-1" src="{{ asset('build/images/GitHub-Mark-32px.png') }}" alt="GitHub logo">

--- a/templates/app/footer.html.twig
+++ b/templates/app/footer.html.twig
@@ -1,14 +1,22 @@
 <footer class="border-t border-gray-200 py-4 text-sm text-gray-600">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between gap-4">
-            <div class="divide-solid">
+            <a class="flex" href="{{ path('app_language') }}">
+                <!-- Heroicon name: solid/language -->
+                <svg class="shrink-0 h-5 w-5 mr-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+                    <path fill-rule="evenodd" d="M9 2.25a.75.75 0 0 1 .75.75v1.506a49.384 49.384 0 0 1 5.343.371.75.75 0 1 1-.186 1.489c-.66-.083-1.323-.151-1.99-.206a18.67 18.67 0 0 1-2.97 6.323c.318.384.65.753 1 1.107a.75.75 0 0 1-1.07 1.052A18.902 18.902 0 0 1 9 13.687a18.823 18.823 0 0 1-5.656 4.482.75.75 0 0 1-.688-1.333 17.323 17.323 0 0 0 5.396-4.353A18.72 18.72 0 0 1 5.89 8.598a.75.75 0 0 1 1.388-.568A17.21 17.21 0 0 0 9 11.224a17.168 17.168 0 0 0 2.391-5.165 48.04 48.04 0 0 0-8.298.307.75.75 0 0 1-.186-1.489 49.159 49.159 0 0 1 5.343-.371V3A.75.75 0 0 1 9 2.25ZM15.75 9a.75.75 0 0 1 .68.433l5.25 11.25a.75.75 0 1 1-1.36.634l-1.198-2.567h-6.744l-1.198 2.567a.75.75 0 0 1-1.36-.634l5.25-11.25A.75.75 0 0 1 15.75 9Zm-2.672 8.25h5.344l-2.672-5.726-2.672 5.726Z" clip-rule="evenodd" />
+                </svg>
+                {{ app.request.locale|locale_name(app.request.locale)|capitalize }}
+            </a>
+
+            <!--<div class="divide-solid">
                 {% for locale in welcome.locales %}
                 {% if loop.index0 > 0 %} &bull; {% endif %}
                 <a href="?l={{ locale }}">{{ locale|locale_name(locale)|capitalize }}</a>
                 {% endfor %}
-            </div>
+            </div>-->
 
-            <div class="flex items-center gap-2 w-48">
+            <div class="flex items-center gap-2">
                 <div class="flex items-center">
                     <img class="h-4 mr-1" src="{{ asset('build/images/GitHub-Mark-32px.png') }}" alt="GitHub logo">
                     <a target="_blank" href="https://github.com/osmbe/osm-welcome-tool">GitHub</a>

--- a/templates/app/home/continent.html.twig
+++ b/templates/app/home/continent.html.twig
@@ -4,17 +4,7 @@
 
 {% block content %}
 
-<div class="flex-1 min-w-0">
-    <p>
-        {{ 'This is the OpenStreetMap Welcome Tool.\r\nIt helps you discover new mappers in your region and welcome them.'|trans|nl2br }}
-    </p>
-    <p>
-        {{ 'If you want to add your region or your language to the Welcome Tool, check our {contributing_link_start}contributing guide{link_end}.'|trans({'{contributing_link_start}': '<a class="text-indigo-600 hover:text-indigo-900" target="_blank" href="https://github.com/osmbe/osm-welcome-tool/blob/2.x/CONTRIBUTING.md">', '{link_end}': '</a>'})|raw }}
-    </p>
-    <p class="mt-3 text-sm">
-        {{ 'Developed by {osmbe_link_start}OpenStreetMap Belgium{link_end} and supported by the {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.'|trans({'{osmbe_link_start}': '<a class="text-indigo-600 hover:text-indigo-900" target="_blank" href="https://openstreetmap.be/">', '{lccwg_link_start}': '<a class="text-indigo-600 hover:text-indigo-900" target="_blank" href="https://wiki.osmfoundation.org/wiki/Local_Chapters_and_Communities_Working_Group">', '{link_end}': '</a>'})|raw }}
-    </p>
-</div>
+{{ include('app/banner.html.twig') }}
 
 <ul role="list" class="mt-5 mb-3 divide-y divide-gray-100 overflow-hidden bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl">
 

--- a/templates/app/home/language.html.twig
+++ b/templates/app/home/language.html.twig
@@ -1,20 +1,19 @@
-{% extends 'base.html.twig' %}
+{% extends 'app/layout.html.twig' %}
 
-{% block title %}Hello LanguageController!{% endblock %}
+{% block title %}{{ welcome.title }}{% endblock %}
 
-{% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
+{% block content %}
 
-<div class="example-wrapper">
-    <h1>Hello {{ controller_name }}! ✅</h1>
+{{ include('app/banner.html.twig') }}
 
-    This friendly message is coming from:
-    <ul>
-        <li>Your controller at <code>/workspaces/osm-welcome-tool/src/Controller/LanguageController.php</code></li>
-        <li>Your template at <code>/workspaces/osm-welcome-tool/templates/language/index.html.twig</code></li>
-    </ul>
+<div class="pt-5 mb-3">
+    <h3 class="text-xl font-medium leading-6 text-gray-900">{{ 'Language'|trans }}</h3>
 </div>
+
+<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+    {% for locale in welcome.locales %}
+        <a href="?l={{ locale }}">{{ locale|locale_name(locale) }}</a>
+    {% endfor %}
+</div>
+
 {% endblock %}

--- a/templates/app/home/language.html.twig
+++ b/templates/app/home/language.html.twig
@@ -1,0 +1,20 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Hello LanguageController!{% endblock %}
+
+{% block body %}
+<style>
+    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
+    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
+</style>
+
+<div class="example-wrapper">
+    <h1>Hello {{ controller_name }}! ✅</h1>
+
+    This friendly message is coming from:
+    <ul>
+        <li>Your controller at <code>/workspaces/osm-welcome-tool/src/Controller/LanguageController.php</code></li>
+        <li>Your template at <code>/workspaces/osm-welcome-tool/templates/language/index.html.twig</code></li>
+    </ul>
+</div>
+{% endblock %}

--- a/templates/app/home/region.html.twig
+++ b/templates/app/home/region.html.twig
@@ -4,17 +4,7 @@
 
 {% block content %}
 
-<div class="flex-1 min-w-0">
-    <p>
-        {{ 'This is the OpenStreetMap Welcome Tool.\r\nIt helps you discover new mappers in your region and welcome them.'|trans|nl2br }}
-    </p>
-    <p>
-        {{ 'If you want to add your region or your language to the Welcome Tool, check our {contributing_link_start}contributing guide{link_end}.'|trans({'{contributing_link_start}': '<a class="text-indigo-600 hover:text-indigo-900" target="_blank" href="https://github.com/osmbe/osm-welcome-tool/blob/2.x/CONTRIBUTING.md">', '{link_end}': '</a>'})|raw }}
-    </p>
-    <p class="mt-3 text-sm">
-        {{ 'Developed by {osmbe_link_start}OpenStreetMap Belgium{link_end} and supported by the {lccwg_link_start}Local Chapters and Communities Working Group{link_end}.'|trans({'{osmbe_link_start}': '<a class="text-indigo-600 hover:text-indigo-900" target="_blank" href="https://openstreetmap.be/">', '{lccwg_link_start}': '<a class="text-indigo-600 hover:text-indigo-900" target="_blank" href="https://wiki.osmfoundation.org/wiki/Local_Chapters_and_Communities_Working_Group">', '{link_end}': '</a>'})|raw }}
-    </p>
-</div>
+{{ include('app/banner.html.twig') }}
 
 <div class="pt-5 mb-3" id="{{ continent }}">
     <h3 class="text-xl font-medium leading-6 text-gray-900">{{ continent|trans }}</h3>


### PR DESCRIPTION
The list of available languages becomes a bit too long to be able to display in the footer.

I've added a page to choose the language and only display the current language in the footer (with a link to the language selection page).

Side note: the "banner" was already shown in 2 different pages (and now 3) so I've made a separated component for it.